### PR TITLE
Support to shipping lines and shipping contact inside "Order create"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,22 @@ Wrapper to connect with https://api.conekta.io.
 
 [conekta-elixir documentation](https://hexdocs.pm/conekta/api-reference.html)
 
-
 ## Setup
+
+### Installation
+
+Add Conekta to your `mix.exs` dependencies:
+
+```elixir
+#mix.exs
+defp deps do
+  [
+    #If you have troubles with poison add
+    #{:poison, "~> 3.1", override: true}
+    {:conekta, "~> 1.0"}
+  ]
+end
+```
 
 ### Configuration
 Add your keys in your `config.exs` file

--- a/lib/conekta/conekta_structs.ex
+++ b/lib/conekta/conekta_structs.ex
@@ -30,7 +30,7 @@ end
 
 defmodule Conekta.Order do
     @moduledoc false
-    defstruct currency: nil, customer_info: nil, line_items: nil, charges: nil
+    defstruct currency: nil, customer_info: nil, line_items: nil, charges: nil, shipping_lines: nil, shipping_contact: nil
 end
 
 defmodule Conekta.OrdersResponse do

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -28,12 +28,27 @@ defmodule ConektaTest.ClientTest do
           customer_info: %{
               customer_id: "cus_2gXnQrxEpkdNfeeFT"
           },
+          shipping_lines: [
+            %{
+              amount:  10000,
+              carrier: "Fake Carrier"
+            }
+          ],
+          shipping_contact: %{
+            phone: "1234567890",
+            address: %{
+              street1: "Fake Address",
+              postal_code: "00000",
+              country: "Country"
+            }
+          },
           line_items: [%{
               name: "Testing",
               unit_price: 35000,
               quantity: 1
           }],
           charges: [%{
+              amount: 45000,
               payment_method: %{
                   type: "default"
               }


### PR DESCRIPTION
All the test were successful, except for one that says "Unrecognized access key", it is also in the original version. 